### PR TITLE
Recognize parametric types

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -88,11 +88,19 @@ function initmeta(m::Module)
     nothing
 end
 
+struct TypeParams{T<:Tuple} end
+
 function signature!(tv::Vector{Any}, expr::Expr)
     is_macrocall = isexpr(expr, :macrocall)
     if is_macrocall || isexpr(expr, :call)
         sig = :(Union{Tuple{}})
         first_arg = is_macrocall ? 3 : 2 # skip function arguments
+        if isexpr(expr.args[1], :curly)
+            push!((sig.args[end]::Expr).args, :($TypeParams{Tuple{$((expr.args[1]::Expr).args[2:end]...)}}))
+            if isempty(tv)
+                append!(tv, mapany(tvar, (expr.args[1]::Expr).args[2:end]))
+            end
+        end
         for arg in expr.args[first_arg:end]
             isexpr(arg, :parameters) && continue
             if isexpr(arg, :kw) # optional arg


### PR DESCRIPTION
I just ran into a similar issue based on this signature recognition bug: if you have a method with `(::Any)` signature and another one with type parameters, you cannot selectively print the one with type parameters only in the documentation, as the generic one will always be found.
Regarding your analysis, I would propose a change that still allows to differentiate parametric constructors. For this, I add the parameters of the constructor as a unique type to the front of the method signature.
Here, I also preserve the behavior that you need not specify the `where` part for constructors, but I completely agree with your analysis that in this way, it is impossible to make the distinction between existing types and parametric types (which cannot be done well during macro deconstruction). This is also an issue in the code currently in Base; _any_ type parameter will always be seen as parametric. For this reason, I'd rather see this whole behavior disappear; in the end, you cannot write Julia code like this. Removing the `if isempty` would prevent this. A kind of middle ground would be to allow the current behavior, but only if the type is constrained (because this would not be possible for existing types).